### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+This is a Hugo static portfolio site with an npm-workspace monorepo for browser games. The site uses the **Toha** theme (git submodule at `themes/toha`). Three games (`void_strike`, `neon_breach`, `botanical_brawl`) are Vite/TypeScript builds; the remaining games are static HTML/JS under `static/games/`.
+
+### System dependencies
+
+- **Node.js 24** — required by `netlify.toml`.
+- **Hugo v0.100.2 (extended)** — install from [GitHub releases](https://github.com/gohugoio/hugo/releases/tag/v0.100.2). Must be the `extended` variant (needed for SCSS).
+
+### Key commands
+
+| Task | Command |
+|------|---------|
+| Install deps | `npm install` (from repo root) |
+| Build games | `npm run build:games` |
+| Build full site | `hugo --gc --minify` |
+| Dev server (Hugo) | `hugo server --bind 0.0.0.0 --port 1313 --disableFastRender` |
+| Dev server (single game) | `npm run dev -- <game_name>` (e.g. `void_strike`) |
+| Full production build | `npm install && npm run build:games && hugo --gc --minify` |
+
+### Caveats
+
+- Git submodules must be initialized before Hugo can build: `git submodule update --init --recursive`.
+- The Vite game builds output to `static/games/<name>/`. These built files are committed to the repo so Hugo can serve them. After running `npm run build:games`, Hugo picks them up as static assets.
+- Hugo's dev server (`hugo server`) serves the site with live-reload. It does **not** serve Netlify Functions. To test serverless functions locally (weapon forge in Wizard Brawl / Botanical Brawl), install `netlify-cli` and use `netlify dev`.
+- The serverless functions (`netlify/functions/`) require `GEMINI_API_KEY` env var for AI weapon generation; they gracefully degrade without it.
+- There are no automated test suites or lint commands configured in `package.json`. The `.pre-commit-config.yaml` defines hooks for YAML/JSON/TOML validation, markdown linting, and trailing whitespace, but these are CI-only (`ci:` block).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development instructions for this Hugo portfolio site with npm workspace games.

### What's included

- Overview of the codebase architecture (Hugo + Toha theme + Vite/TS game monorepo)
- System dependency requirements (Node.js 24, Hugo v0.100.2 extended)
- Key development commands table (install, build, dev server, etc.)
- Important caveats for cloud agents (git submodules, Vite game output, Netlify Functions, etc.)

### Development environment setup

The update script initializes git submodules and runs `npm install`:

```bash
git submodule update --init --recursive
npm install
```

### Verified

- Node.js v24 installed and working
- Hugo v0.100.2 (extended) installed and working
- Git submodules initialized (themes/toha)
- npm workspace dependencies installed (42 packages)
- All 3 Vite games built successfully (botanical_brawl, neon_breach, void_strike)
- Hugo site built (39 pages, 1166 static files)
- Hugo dev server running on port 1313 with all pages loading correctly

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8ea07163-bcf2-4ba8-b3ea-7844f79d701a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8ea07163-bcf2-4ba8-b3ea-7844f79d701a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

