### PR TITLE
fix: prevent RangeError when sharing large translation chains

### DIFF
--- a/games/lost_in_translation/src/storage.ts
+++ b/games/lost_in_translation/src/storage.ts
@@ -51,7 +51,7 @@ export function setCachedChain(chain: TranslationChain): void {
 export function encodeChainToHash(chain: TranslationChain): string {
   const json = JSON.stringify(chain);
   const compressed = pako.deflate(new TextEncoder().encode(json));
-  const base64 = btoa(String.fromCharCode(...compressed));
+  const base64 = btoa(Array.from(compressed, b => String.fromCharCode(b)).join(''));
   return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 


### PR DESCRIPTION
## Summary

- Fixed a RangeError in encodeChainToHash (storage.ts:54) in the Lost in Translation game
- Spreading a Uint8Array as arguments to String.fromCharCode fails when the compressed payload exceeds V8s argument limit, silently breaking URL sharing for long translation chains
- Replaced with Array.from iteration which does not hit the limit

## What a reviewer should know

One-line fix. The decode path already uses the safe pattern, this brings encode in line with it.

Generated with Claude Code